### PR TITLE
Refactored question service and added new category: 'Guess the city'

### DIFF
--- a/gatewayservice/gateway-service.js
+++ b/gatewayservice/gateway-service.js
@@ -43,21 +43,31 @@ app.post('/adduser', async (req, res) => {
   }
 });
 
-app.get('/flags/question', async (req, res) => {
+app.get('/imgs/flags/question', async (req, res) => {
   try {
     // Forward the request to the question service
-    const questionResponse = await axios.get(questionServiceUrl+'/flags/question', req.body);
+    const questionResponse = await axios.get(questionServiceUrl+'/imgs/flags/question', req.body);
     res.json(questionResponse.data);
   } catch (error) {
     res.status(error.response.status).json({ error: error.response.data.error });
   }
 });
 
-app.post('/flags/answer', async (req, res) => {
+app.get('/imgs/cities/question', async (req, res) => {
+  try {
+    // Forward the request to the question service
+    const questionResponse = await axios.get(questionServiceUrl+'/imgs/cities/question', req.body);
+    res.json(questionResponse.data);
+  } catch (error) {
+    res.status(error.response.status).json({ error: error.response.data.error });
+  }
+});
+
+app.post('/imgs/answer', async (req, res) => {
   try {
     const answer = req.body.answer;
     // Forward the request to the question service
-    const questionResponse = await axios.post(questionServiceUrl+'/flags/answer', answer, { headers: {'Content-Type': 'text/plain'} });
+    const questionResponse = await axios.post(questionServiceUrl+'/imgs/answer', answer, { headers: {'Content-Type': 'text/plain'} });
     res.json(questionResponse.data);
   } catch (error) {
     res.status(error.response.status).json({ error: error.response.data.error });

--- a/webapp/src/components/Game.jsx
+++ b/webapp/src/components/Game.jsx
@@ -5,12 +5,16 @@ import useAuthUser from "react-auth-kit/hooks/useAuthUser";
 import Question from "./Question";
 
 const Game = () => {
-    const [gameStarted, setGameStarted] = useState(false);
+    const [flagGameStarted, setFlagGameStarted] = useState(false);
+    const [cityGameStarted, setCityGameStarted] = useState(false);
     const isAuthenticated = useIsAuthenticated();
     const navigate = useNavigate();
     const auth = useAuthUser();
-    const startGame = () => {
-        setGameStarted(!gameStarted);
+    const startFlagsGame = () => {
+        setFlagGameStarted(!flagGameStarted);
+    };
+    const startCitiesGame = () => {
+        setCityGameStarted(!cityGameStarted);
     };
     useEffect(() => {
         if (!isAuthenticated()) {
@@ -20,17 +24,24 @@ const Game = () => {
 
     return (
         <div>
-            {isAuthenticated()?gameStarted ? (
-                <Question />
+            {isAuthenticated() && (flagGameStarted || cityGameStarted) ?(
+                <div>
+                    {flagGameStarted && <Question type="imgs" category="flags"/>}
+                    {cityGameStarted && <Question type="imgs" category="cities"/>}
+                </div>
             ) : (
                 <div className="flex flex-col items-center justify-center mt-16">
                     <h1 className="text-6xl font-bold text-zinc-700">{auth.username}, Let's Play!</h1>
-                    <button onClick={startGame} className="mt-10 border border-blue-500 text-blue-500 font-bold text-2xl py-2 px-4 rounded-full 
+                    <button onClick={startFlagsGame} className="mt-10 border border-blue-500 text-blue-500 font-bold text-2xl py-2 px-4 rounded-full 
                         transition-transform transform-gpu hover:scale-105">
-                    Play
+                    Guess the flag
+                    </button>
+                    <button onClick={startCitiesGame} className="mt-10 border border-blue-500 text-blue-500 font-bold text-2xl py-2 px-4 rounded-full 
+                        transition-transform transform-gpu hover:scale-105">
+                    Guess the city
                     </button>
                 </div>
-            ):""}
+            )}
         </div>
     )
 };

--- a/webapp/src/components/Question.jsx
+++ b/webapp/src/components/Question.jsx
@@ -1,14 +1,14 @@
 import React, { useState, useEffect } from "react";
 import axios from "axios";
 
-const Question = () => {
+const Question = (props) => {
     const apiEndpoint =  process.env.REACT_APP_API_ENDPOINT ||'http://localhost:8000';
     const [question, setQuestion] = useState([]);
     const [loading, setLoading] = useState(true);
 
     const fetchQuestion = async () => {
         try {
-            const res = await axios.get(`${apiEndpoint}/flags/question`);
+            const res = await axios.get(`${apiEndpoint}/${props.type}/${props.category}/question`);
             setQuestion(res.data);
             setLoading(false);
         } catch (error) {
@@ -19,8 +19,8 @@ const Question = () => {
     const answerQuestion = async (answer) => {
         try {
             setLoading(true);
-            const result = await axios.post(`${apiEndpoint}/flags/answer`, {answer});
-            const res = await axios.get(`${apiEndpoint}/flags/question`);
+            const result = await axios.post(`${apiEndpoint}/${props.type}/answer`, {answer});
+            const res = await axios.get(`${apiEndpoint}/${props.type}/${props.category}/question`);
             setQuestion(res.data);
             setLoading(false);
 
@@ -41,11 +41,11 @@ const Question = () => {
                     <>
                     <h1 className="font-bold text-3xl text-gray-800 pl-8">{question.question}</h1>
                     <div className="grid grid-cols-2 mt-10 item">
-                    {question.flags.map( flag => (
+                    {question.images.map( image => (
                         <div className="rounded-xl mx-8 my-8">
                             <button className="transition-transform transform-gpu hover:scale-105">
-                                <img src={flag} alt='Loading flag...' className="rounded-lg max-h-50 object-contain shadow-md"
-                                    onClick={() => answerQuestion(flag)}></img>
+                                <img src={image} alt='Loading image...' className="rounded-lg max-h-50 object-contain shadow-md"
+                                    onClick={() => answerQuestion(image)}></img>
                             </button>
                         </div>
                     ))}


### PR DESCRIPTION
Now to create a new category we only have to formulate the sparql query in the format I wrote in the documentation of the method and the question will be generated accordingly, no need to create a new method for these type of questions, just create a new endpoint and use the parametrized method with the adjusted query. 

Also, the answer endpoint is made to be universal for all categories of the same type, so there is no need to create a new one for each category, only if a new type is created.